### PR TITLE
Fix color in navigation list

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -176,7 +176,8 @@ nav {
         }
       }
 
-      .nav-link:hover {
+      .nav-link:hover,
+      .nav-link:focus {
           color: inherit;
       }
 


### PR DESCRIPTION
- Fixed:
  - Previous version made focused `nav-link` to be highlighted in black once another items becomes `active`, e.g.:  
    ![image](https://github.com/EduardSergeev/CV/assets/722409/972d63f5-8457-49d7-b9f3-eab9b9384839)
